### PR TITLE
Fix tracing compile error

### DIFF
--- a/examples/puffin/renderer.rs
+++ b/examples/puffin/renderer.rs
@@ -66,12 +66,12 @@ impl Renderer {
             Self::upload_font_atlas(&resource_manager, &graphics_queue, font_atlas_texture)?;
 
         Ok(Renderer {
-            api,
-            swapchain_helper,
-            graphics_queue,
-            imgui_pass,
-            resource_manager,
             font_atlas_texture,
+            imgui_pass,
+            graphics_queue,
+            swapchain_helper,
+            resource_manager,
+            api,
         })
     }
 

--- a/profiling-procmacros/src/lib.rs
+++ b/profiling-procmacros/src/lib.rs
@@ -89,7 +89,7 @@ fn impl_block(
 ) -> syn::Block {
     parse_quote! {
         {
-            let _fn_span = profiling::tracing::span!(tracing::Level::INFO, #instrumented_function_name);
+            let _fn_span = profiling::tracing::span!($crate::tracing::Level::INFO, #instrumented_function_name);
             let _fn_span_entered = _fn_span.enter();
 
             #body

--- a/profiling-procmacros/src/lib.rs
+++ b/profiling-procmacros/src/lib.rs
@@ -89,7 +89,7 @@ fn impl_block(
 ) -> syn::Block {
     parse_quote! {
         {
-            let _fn_span = profiling::tracing::span!($crate::tracing::Level::INFO, #instrumented_function_name);
+            let _fn_span = profiling::tracing::span!(profiling::tracing::Level::INFO, #instrumented_function_name);
             let _fn_span_entered = _fn_span.enter();
 
             #body

--- a/src/tracing_impl.rs
+++ b/src/tracing_impl.rs
@@ -1,11 +1,11 @@
 #[macro_export]
 macro_rules! scope {
     ($name:expr) => {
-        let _span = $crate::tracing::span!(tracing::Level::INFO, $name);
+        let _span = $crate::tracing::span!($crate::tracing::Level::INFO, $name);
         let _span_entered = _span.enter();
     };
     ($name:expr, $data:expr) => {
-        let _span = $crate::tracing::span!(tracing::Level::INFO, $name, tag = $data);
+        let _span = $crate::tracing::span!($crate::tracing::Level::INFO, $name, tag = $data);
         let _span_entered = _span.enter();
     };
 }


### PR DESCRIPTION
Occurs when the downstream crate adds profiling as a dependency, enables "profile-with-tracing" feature, but does no add tracing as a dependency. Fixes #21 