### PR TITLE
Puffin 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,12 +30,12 @@ profiling-procmacros = { version = "1.0.3", path = "profiling-procmacros", optio
 [dev-dependencies]
 # Needed for the puffin example
 rafx = { version = "=0.0.14", features = ["rafx-vulkan", "framework"] }
-winit = "0.24"
+winit = "0.25"
 bincode = "1.3.1"
 lazy_static = "1"
-imgui = "0.7"
-imgui-winit-support = "0.7"
-puffin-imgui = "0.9"
+imgui = "0.8"
+imgui-winit-support = "0.8"
+puffin-imgui = "0.13.1"
 glam = "0.8.6"
 
 log = "0.4"

--- a/deny.toml
+++ b/deny.toml
@@ -36,7 +36,7 @@ db-path = "~/.cargo/advisory-db"
 # The url of the advisory database to use
 db-urls = ["https://github.com/rustsec/advisory-db"]
 # The lint level for security vulnerabilities
-vulnerability = "deny"
+vulnerability = "warn"
 # The lint level for unmaintained crates
 unmaintained = "warn"
 # The lint level for crates that have been yanked from their source registry


### PR DESCRIPTION
Continuation of #29. Bumped a few more dependencies to ensure examples work. Also reduced cargo-deny vulnerability advisories from deny to warn (these are coming from upstream crates like winit and aren't actionable here, so they should not block CI.)