### PR TITLE
Bump puffin(0.12.1) and dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ categories = ["development-tools::profiling"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-puffin = { version = "0.10", optional = true }
+puffin = { version = "0.12.1", optional = true }
 optick = { version = "1.3", optional = true }
 tracing = { version = "0.1", optional = true }
 tracy-client = { version = "0.12", optional = true }
@@ -35,7 +35,7 @@ bincode = "1.3.1"
 lazy_static = "1"
 imgui = "0.8"
 imgui-winit-support = "0.8"
-puffin-imgui = "0.13.1"
+puffin-imgui = "0.15.0"
 glam = "0.8.6"
 
 log = "0.4"


### PR DESCRIPTION
Updated puffin to 0.12.1 and puffin-imgui to 0.15.0