### PR TITLE
Update tracy_client to 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ categories = ["development-tools::profiling"]
 puffin = { version = "0.12.1", optional = true }
 optick = { version = "1.3", optional = true }
 tracing = { version = "0.1", optional = true }
-tracy-client = { version = "0.12", optional = true }
+tracy-client = { version = "0.13", optional = true }
 superluminal-perf = { version = "0.1", optional = true }
 profiling-procmacros = { version = "1.0.5", path = "profiling-procmacros", optional = true }
 

--- a/examples/puffin/renderer.rs
+++ b/examples/puffin/renderer.rs
@@ -469,7 +469,7 @@ rafx::declare_render_phase!(
     opaque_render_phase_sort_submit_nodes
 );
 
-fn opaque_render_phase_sort_submit_nodes(_submit_nodes: &mut Vec<RenderFeatureSubmitNode>) {
+fn opaque_render_phase_sort_submit_nodes(_submit_nodes: &mut [RenderFeatureSubmitNode]) {
     // No sort needed
 }
 

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -45,6 +45,9 @@ fn main() {
     println!("Starting loop, profiler can now be attached");
 
     // Test that using this macro multiple times in the same scope level will compile.
+    //
+    // optick backend currently won't work with multiple `profiling::scope!` in the same scope
+    #[cfg(not(any(feature = "profile-with-optick")))]
     {
         profiling::scope!("Outer scope");
         burn_time(5);
@@ -56,6 +59,8 @@ fn main() {
     //
     // Does not work with these two backends:
     #[cfg(not(any(feature = "profile-with-puffin", feature = "profile-with-tracing")))]
+    // optick backend currently won't work with multiple `profiling::scope!` in the same scope
+    #[cfg(not(any(feature = "profile-with-optick")))]
     {
         let scope_name = String::from("Some scope name");
         profiling::scope!(&scope_name);

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -44,6 +44,14 @@ fn main() {
 
     println!("Starting loop, profiler can now be attached");
 
+    // Test that using this macro multiple times in the same scope level will compile.
+    {
+        profiling::scope!("Outer scope");
+        burn_time(5);
+        profiling::scope!("Inner scope");
+        burn_time(5);
+    }
+
     loop {
         // Generate some profiling info
         profiling::scope!("Main Thread");

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -52,6 +52,21 @@ fn main() {
         burn_time(5);
     }
 
+    // Test that non-literals can be used
+    //
+    // Does not work with these two backends:
+    #[cfg(not(any(feature = "profile-with-puffin", feature = "profile-with-tracing")))]
+    {
+        let scope_name = String::from("Some scope name");
+        profiling::scope!(&scope_name);
+        burn_time(5);
+
+        let another_scope_name = String::from("Another scope name");
+        let some_data = String::from("Some data");
+        profiling::scope!(&another_scope_name, &some_data);
+        burn_time(5);
+    }
+
     loop {
         // Generate some profiling info
         profiling::scope!("Main Thread");

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -20,6 +20,10 @@ fn main() {
     feature = "profile-with-tracy",
 ))]
 fn main() {
+    // Starting the Tracy client is necessary before any invoking any of its APIs
+    #[cfg(feature = "profile-with-tracy")]
+    tracy_client::Client::start();
+
     // Good to call this on any threads that are created to get clearer profiling results
     profiling::register_thread!("Main Thread");
 

--- a/profiling-procmacros/src/lib.rs
+++ b/profiling-procmacros/src/lib.rs
@@ -105,7 +105,7 @@ fn impl_block(
     parse_quote! {
         {
             // Note: callstack_depth is 0 since this has significant overhead
-            let _tracy_span = profiling::tracy_client::Span::new(#instrumented_function_name, "", file!(), line!(), 0);
+            let _tracy_span = profiling::tracy_client::span!(#instrumented_function_name, 0);
 
             #body
         }

--- a/src/optick_impl.rs
+++ b/src/optick_impl.rs
@@ -1,13 +1,13 @@
 #[macro_export]
 macro_rules! scope {
-    ($name:expr) => {{
+    ($name:expr) => {
         $crate::optick::event!($name);
-    }};
+    };
     // NOTE: I've not been able to get attached data to work with optick
-    ($name:expr, $data:expr) => {{
+    ($name:expr, $data:expr) => {
         $crate::optick::event!($name);
         $crate::optick::tag!("tag", $data);
-    }};
+    };
 }
 
 #[macro_export]

--- a/src/optick_impl.rs
+++ b/src/optick_impl.rs
@@ -1,13 +1,13 @@
 #[macro_export]
 macro_rules! scope {
-    ($name:expr) => {
+    ($name:expr) => {{
         $crate::optick::event!($name);
-    };
+    }};
     // NOTE: I've not been able to get attached data to work with optick
-    ($name:expr, $data:expr) => {
+    ($name:expr, $data:expr) => {{
         $crate::optick::event!($name);
         $crate::optick::tag!("tag", $data);
-    };
+    }};
 }
 
 #[macro_export]

--- a/src/tracy_impl.rs
+++ b/src/tracy_impl.rs
@@ -1,18 +1,22 @@
 #[macro_export]
 macro_rules! scope {
     ($name:expr) => {
-        struct S;
-        let type_name = core::any::type_name::<S>();
-        let function_name = &type_name[..type_name.len() - 3];
+        let function_name = {
+            struct S;
+            let type_name = core::any::type_name::<S>();
+            &type_name[..type_name.len() - 3]
+        };
         let _tracy_span = $crate::tracy_client::Client::running()
             .expect("scope! without a running tracy_client::Client")
             // Note: callstack_depth is 0 since this has significant overhead
             .span_alloc($name, function_name, file!(), line!(), 0);
     };
     ($name:expr, $data:expr) => {
-        struct S;
-        let type_name = core::any::type_name::<S>();
-        let function_name = &type_name[..type_name.len() - 3];
+        let function_name = {
+            struct S;
+            let type_name = core::any::type_name::<S>();
+            &type_name[..type_name.len() - 3]
+        };
         let _tracy_span = $crate::tracy_client::Client::running()
             .expect("scope! without a running tracy_client::Client")
             .span_alloc($name, function_name, file!(), line!(), 0);

--- a/src/tracy_impl.rs
+++ b/src/tracy_impl.rs
@@ -1,11 +1,21 @@
 #[macro_export]
 macro_rules! scope {
     ($name:expr) => {
-        // Note: callstack_depth is 0 since this has significant overhead
-        let _tracy_span = $crate::tracy_client::Span::new($name, "", file!(), line!(), 0);
+        struct S;
+        let type_name = core::any::type_name::<S>();
+        let function_name = &type_name[..type_name.len() - 3];
+        let _tracy_span = $crate::tracy_client::Client::running()
+            .expect("scope! without a running tracy_client::Client")
+            // Note: callstack_depth is 0 since this has significant overhead
+            .span_alloc($name, function_name, file!(), line!(), 0);
     };
     ($name:expr, $data:expr) => {
-        let _tracy_span = $crate::tracy_client::Span::new($name, "", file!(), line!(), 0);
+        struct S;
+        let type_name = core::any::type_name::<S>();
+        let function_name = &type_name[..type_name.len() - 3];
+        let _tracy_span = $crate::tracy_client::Client::running()
+            .expect("scope! without a running tracy_client::Client")
+            .span_alloc($name, function_name, file!(), line!(), 0);
         _tracy_span.emit_text($data);
     };
 }
@@ -25,7 +35,9 @@ macro_rules! register_thread {
         $crate::register_thread!(&thread_name);
     };
     ($name:expr) => {
-        $crate::tracy_client::set_thread_name($name);
+        $crate::tracy_client::Client::running()
+            .expect("register_thread! without a running tracy_client::Client")
+            .set_thread_name($name);
     };
 }
 
@@ -34,6 +46,8 @@ macro_rules! register_thread {
 #[macro_export]
 macro_rules! finish_frame {
     () => {
-        $crate::tracy_client::finish_continuous_frame!();
+        $crate::tracy_client::Client::running()
+            .expect("finish_frame! without a running tracy_client::Client")
+            .frame_mark();
     };
 }

--- a/src/tracy_impl.rs
+++ b/src/tracy_impl.rs
@@ -1,5 +1,15 @@
 #[macro_export]
 macro_rules! scope {
+    // Note: literal patterns provided as an optimization since they can skip an allocation.
+    ($name:literal) => {
+        // Note: callstack_depth is 0 since this has significant overhead
+        let _tracy_span = $crate::tracy_client::span!($name, 0);
+    };
+    ($name:literal, $data:expr) => {
+        // Note: callstack_depth is 0 since this has significant overhead
+        let _tracy_span = $crate::tracy_client::span!($name, 0);
+        _tracy_span.emit_text($data);
+    };
     ($name:expr) => {
         let function_name = {
             struct S;
@@ -19,6 +29,7 @@ macro_rules! scope {
         };
         let _tracy_span = $crate::tracy_client::Client::running()
             .expect("scope! without a running tracy_client::Client")
+            // Note: callstack_depth is 0 since this has significant overhead
             .span_alloc($name, function_name, file!(), line!(), 0);
         _tracy_span.emit_text($data);
     };


### PR DESCRIPTION
Note, `tracy_client` now requires that the client has been started before running instrumented code. This can be done via:
```rs
tracy_client::Client::start();
```
at the top of `main`.

Should I note this new requirement anywhere in the readme or can we expect users of tracy to understand the necessary setup?

`tracy_client`'s new span macro currently panics when the client has not been started (instead of silently doing nothing), so I went ahead and implemented the same behavior here.

However, there is some discussion about potentially changing this behavior to avoid those panics <https://github.com/nagisa/rust_tracy_client/pull/36#issue-1222267892>.