### PR TITLE
Upgrade to tracy-client 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ categories = ["development-tools::profiling"]
 puffin = { version = "0.12.1", optional = true }
 optick = { version = "1.3", optional = true }
 tracing = { version = "0.1", optional = true }
-tracy-client = { version = "0.13", optional = true }
+tracy-client = { version = "0.14", optional = true }
 superluminal-perf = { version = "0.1", optional = true }
 profiling-procmacros = { version = "1.0.6", path = "profiling-procmacros", optional = true }
 


### PR DESCRIPTION
tracy-client 0.14 released recently, compatible with Tracy 0.8.1.