### PR TITLE
Do not package big files in the crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ repository = "https://github.com/aclysma/profiling"
 homepage = "https://github.com/aclysma/profiling"
 keywords = ["performance", "profiling"]
 categories = ["development-tools::profiling"]
+exclude = ["/examples", "/screenshots"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
`profiling` is the biggest crate in my 300 dependencies, using 1.7MB for no real reason as it is supposed to be a thin abstraction.

The 1.7MB almost entirely comes from a font for the puffing example and a lot of screenshots, the exclude field in the manifest file should exclude them from any future package.