### PR TITLE
Update `tracy-client` dependency to support Tracy 0.8.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ exclude = ["/examples", "/screenshots"]
 puffin = { version = "0.12.1", optional = true }
 optick = { version = "1.3", optional = true }
 tracing = { version = "0.1", optional = true }
-tracy-client = { version = "0.13", optional = true }
+tracy-client = { version = "0.14", optional = true }
 superluminal-perf = { version = "0.1", optional = true }
 profiling-procmacros = { version = "1.0.6", path = "profiling-procmacros", optional = true }
 


### PR DESCRIPTION
Update the `tracy-client` dependency since https://github.com/nagisa/rust_tracy_client/issues/51 has been resolved.

Test success with `profiling = { git = "https://github.com/Latias94/profiling", branch = "tracy-0.14.1" }`

```shell
❯ cd profiling
❯ cargo update
    Updating crates.io index
    Updating tracy-client-sys v0.17.1 -> v0.18.0
❯ cargo tree --features="profile-with-tracy"
profiling v1.0.6 (D:\Github-Projects\profiling)
├── profiling-procmacros v1.0.6 (proc-macro) (D:\Github-Projects\profiling\profiling-procmacros)
│   ├── quote v1.0.21
│   │   └── proc-macro2 v1.0.46
│   │       └── unicode-ident v1.0.4
│   └── syn v1.0.101
│       ├── proc-macro2 v1.0.46 (*)
│       ├── quote v1.0.21 (*)
│       └── unicode-ident v1.0.4
└── tracy-client v0.14.1
    ├── once_cell v1.15.0
    └── tracy-client-sys v0.18.0
        [build-dependencies]
        └── cc v1.0.73
            └── jobserver v0.1.25
```