### PR TITLE
Bump tracy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ exclude = ["/examples", "/screenshots"]
 puffin = { version = "0.12.1", optional = true }
 optick = { version = "1.3", optional = true }
 tracing = { version = "0.1", optional = true }
-tracy-client = { version = "0.14.1", optional = true }
+tracy-client = { version = "0.15.0", optional = true }
 superluminal-perf = { version = "0.1", optional = true }
 profiling-procmacros = { version = "1.0.7", path = "profiling-procmacros", optional = true }
 


### PR DESCRIPTION
Tracy has been updated and contains a change I'd like to use without having to manually patch this crate.
Could the tracy dependency be updated an a new release made?