### PR TITLE
opt out of std, but backends have not been tested

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ tracing-subscriber = { version = "0.2" }
 
 [features]
 default = ["procmacros"]
+no-std = []
 profile-with-puffin = ["puffin", "profiling-procmacros/profile-with-puffin"]
 profile-with-optick = ["optick", "profiling-procmacros/profile-with-optick"]
 profile-with-superluminal = ["superluminal-perf", "profiling-procmacros/profile-with-superluminal"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,8 @@
 // exact same interface. Only one may be active at a time.
 //
 
+#![cfg_attr(fetaure = "no-std", no_std)]
+
 /// Proc macro for creating a scope around the function, using the name of the function for the
 /// scope's name
 ///


### PR DESCRIPTION
Closes #47 

I opted to add a `no-std` feature instead of the common `std + default = ["std", ...]` combo to simplify the setup from this:
`default-features = false, features = ["profiling-procmacros"]` to this `features = ["no-std"]`, because without the macros the create is pointless.

Cheers!