### PR TITLE
Update to puffin 0.16 and dev-dependency puffin-imgui 0.22

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ exclude = ["/examples", "/screenshots"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-puffin = { version = "0.12.1", optional = true }
+puffin = { version = "0.16", optional = true }
 optick = { version = "1.3", optional = true }
 tracing = { version = "0.1", optional = true }
 tracy-client = { version = "0.15.1", optional = true }
@@ -31,12 +31,12 @@ profiling-procmacros = { version = "1.0.8", path = "profiling-procmacros", optio
 [dev-dependencies]
 # Needed for the puffin example
 rafx = { version = "=0.0.14", features = ["rafx-vulkan", "framework"] }
-winit = "0.25"
+winit = "0.27"
 bincode = "1.3.1"
 lazy_static = "1"
-imgui = "0.8"
-imgui-winit-support = "0.8"
-puffin-imgui = "0.15.0"
+imgui = "0.10"
+imgui-winit-support = "0.10"
+puffin-imgui = "0.22"
 glam = "0.8.6"
 
 log = "0.4"

--- a/deny.toml
+++ b/deny.toml
@@ -74,8 +74,8 @@ allow = [
     "Apache-2.0",
     "BSD-3-Clause",
     "Zlib",
-    "Unicode-DFS-2016"
-    #"BSD-2-Clause"
+    "Unicode-DFS-2016",
+    "BSD-2-Clause"
     #"Apache-2.0 WITH LLVM-exception",
 ]
 # List of explictly disallowed licenses
@@ -108,6 +108,9 @@ confidence-threshold = 1.0
 exceptions = [
     # used by ash in an example
     { allow = ["ISC"], name = "libloading", version = "*" },
+    # used indirectly by winit. Allowed for now because this is a dev-dependency only. In general this library will not
+    # accept upstream copy-left licenses
+    { allow = ["MPL-2.0"], name = "dwrote", version = "*" }
 ]
 
 # Some crates don't have (easily) machine readable licensing information,

--- a/examples/puffin/imgui_support.rs
+++ b/examples/puffin/imgui_support.rs
@@ -59,7 +59,7 @@ impl ImguiManager {
     ) -> Self {
         // Ensure font atlas is built and cache a pointer to it
         let font_atlas_texture = {
-            let mut fonts = imgui_context.fonts();
+            let fonts = imgui_context.fonts();
             let font_atlas_texture = Box::new(fonts.build_rgba32_texture());
             log::info!("Building ImGui font atlas");
 

--- a/examples/puffin/imgui_support.rs
+++ b/examples/puffin/imgui_support.rs
@@ -36,11 +36,11 @@ impl Drop for Inner {
 
         // Drop the UI call if it exists
         if let Some(ui) = ui {
-            let _ui = unsafe { Box::from_raw(ui) };
+            unsafe { drop(Box::from_raw(ui)) };
         }
 
         // Drop the font atlas
-        unsafe { Box::from_raw(self.font_atlas_texture) };
+        unsafe { drop(Box::from_raw(self.font_atlas_texture)) };
     }
 }
 

--- a/examples/puffin/puffin.rs
+++ b/examples/puffin/puffin.rs
@@ -54,7 +54,7 @@ fn main() {
     puffin::set_scopes_on(true);
 
     // Create the winit event loop
-    let event_loop = winit::event_loop::EventLoop::<()>::with_user_event();
+    let event_loop = winit::event_loop::EventLoopBuilder::<()>::with_user_event().build();
 
     // Set up the coordinate system to be fixed at 900x600, and use this as the default window size
     // This means the drawing code can be written as though the window is always 900x600. The


### PR DESCRIPTION
- Update other dev-dependencies required to keep the demo functional (winit, imgui, imgui-winit-support)
- Some internal example-only imgui code changes due to upstream API changes
- Allow-list upstream MPL-licensed dependency "dwrote" as it is required for winit. This is a dev-dependency only. Generally this repo will not accept changes that add upstream dependencies with copy-left licenses.