### PR TITLE
Impl two new macro `#[profiling::all_functions]` and `#[profiling::skip]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 1.0.9
- * Add `profiling::auto_impl`
+ * Add `profiling::all_functions`
  * Add `profiling::skip`
 
 ## 1.0.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.9
+ * Add `profiling::auto_impl`
+ * Add `profiling::skip`
+
 ## 1.0.8
  * Update tracy-client to 0.15.1
  * Add no_std (std likely is still required for any backends to be turned on)

--- a/README.md
+++ b/README.md
@@ -69,10 +69,10 @@ Currently, there's just six macros:
      * tag: optional extra data
  * `#[profiling::function]`
      * procmacro placed on a function to quickly wrap it in a scope using the function name
- * `#[profiling::auto_impl]`
+ * `#[profiling::all_functions]`
      * procmacro placed on a struct impl block to apply `#[profiling::function]` on each function under that struct impl block
  * `#[profiling::skip]`
-     * use with `#[profiling::auto_impl]`, placed this procmacro on a function to avoid the auto-impl action
+     * use with `#[profiling::all_functions]`, placed this procmacro on a function to avoid the  action that `#[profiling::all_functions]` apply
  * `profiling::register_thread!([name: &str])`
      * name: optional, defaults to `std::thread::current().name`, or `.id` if it's unnamed
  * `profiling::finish_frame!()`

--- a/README.md
+++ b/README.md
@@ -63,12 +63,16 @@ This allows existing and new tracing-compatible handlers to work with profiling.
 
 ## Usage
 
-Currently, there's just four macros:
+Currently, there's just six macros:
  * `profiling::scope!(name: &str, [tag: &str])`
      * name: scopes will appear in the profiler under this name
      * tag: optional extra data
  * `#[profiling::function]`
      * procmacro placed on a function to quickly wrap it in a scope using the function name
+ * `#[profiling::auto_impl]`
+     * procmacro placed on a struct impl block to apply `#[profiling::function]` on each function under that struct impl block
+ * `#[profiling::skip]`
+     * use with `#[profiling::auto_impl]`, placed this procmacro on a function to avoid the auto-impl action
  * `profiling::register_thread!([name: &str])`
      * name: optional, defaults to `std::thread::current().name`, or `.id` if it's unnamed
  * `profiling::finish_frame!()`

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -11,6 +11,20 @@ fn main() {
     panic!("No profiler feature flags were enabled. Since this is an example, this is probably a mistake.");
 }
 
+struct Foo;
+
+#[profiling::auto_impl]
+impl Foo {
+    pub fn with_auto_impl() {
+        some_other_function(5);
+    }
+
+    #[profiling::skip]
+    pub fn without_auto_impl() {
+        some_other_function(5);
+    }
+}
+
 // Just check that one of these features was enabled because otherwise, nothing interesting will happen
 #[cfg(any(
     feature = "profile-with-optick",
@@ -77,6 +91,9 @@ fn main() {
         profiling::scope!("Main Thread");
         some_function();
         some_other_function(10);
+
+        Foo::with_auto_impl();
+        Foo::without_auto_impl();
 
         println!("frame complete");
 

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -13,14 +13,14 @@ fn main() {
 
 struct Foo;
 
-#[profiling::auto_impl]
+#[profiling::all_functions]
 impl Foo {
-    pub fn with_auto_impl() {
+    pub fn function1() {
         some_other_function(5);
     }
 
     #[profiling::skip]
-    pub fn without_auto_impl() {
+    pub fn function2() {
         some_other_function(5);
     }
 }
@@ -92,8 +92,8 @@ fn main() {
         some_function();
         some_other_function(10);
 
-        Foo::with_auto_impl();
-        Foo::without_auto_impl();
+        Foo::function1();
+        Foo::function2();
 
         println!("frame complete");
 

--- a/profiling-procmacros/src/lib.rs
+++ b/profiling-procmacros/src/lib.rs
@@ -65,7 +65,7 @@ pub fn auto_impl(
         for func_attr in &func.attrs {
             if let syn::Meta::Path(ref func_attr_info) = func_attr.meta {
                 let attr_seg = func_attr_info.segments.last().unwrap();
-                if attr_seg.ident.to_string() == "skip".to_string() {
+                if attr_seg.ident == *"skip" {
                     continue 'func_loop;
                 }
             }

--- a/profiling-procmacros/src/lib.rs
+++ b/profiling-procmacros/src/lib.rs
@@ -1,7 +1,7 @@
 extern crate proc_macro;
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, parse_quote, ItemFn};
+use syn::{parse_macro_input, parse_quote, ImplItem, ItemFn, ItemImpl};
 
 #[proc_macro_attribute]
 pub fn function(
@@ -31,7 +31,10 @@ pub fn skip(
 }
 
 #[proc_macro_attribute]
-pub fn impl(_attr: TokenStream, item: TokenStream) -> TokenStream {
+pub fn auto_impl(
+    _attr: TokenStream,
+    item: TokenStream,
+) -> TokenStream {
     let mut content = parse_macro_input!(item as ItemImpl);
     'func_loop: for block in &mut content.items {
         match block {
@@ -54,7 +57,6 @@ pub fn impl(_attr: TokenStream, item: TokenStream) -> TokenStream {
             _ => {}
         }
     }
-    // println!("item: \"{:?}\"", content.attrs.);
 
     (quote!(
         #content

--- a/profiling-procmacros/src/lib.rs
+++ b/profiling-procmacros/src/lib.rs
@@ -65,11 +65,15 @@ pub fn all_functions(
         };
 
         for func_attr in &func.attrs {
-            if let syn::Meta::Path(ref func_attr_info) = func_attr.meta {
-                let attr_seg = func_attr_info.segments.last().unwrap();
-                if attr_seg.ident == *"skip" {
-                    continue 'func_loop;
-                }
+            let func_attr_info = func_attr.path();
+            if func_attr_info.segments.is_empty() {
+                unreachable!();
+            }
+            if func_attr_info.segments.first().unwrap().ident != "profiling" {
+                continue;
+            }
+            if func_attr_info.segments.last().unwrap().ident == "skip" {
+                continue 'func_loop;
             }
         }
         let prev_block = &func.block;

--- a/profiling-procmacros/src/lib.rs
+++ b/profiling-procmacros/src/lib.rs
@@ -67,7 +67,7 @@ pub fn all_functions(
         for func_attr in &func.attrs {
             let func_attr_info = func_attr.path();
             if func_attr_info.segments.is_empty() {
-                unreachable!();
+                continue;
             }
             if func_attr_info.segments.first().unwrap().ident != "profiling" {
                 continue;

--- a/profiling-procmacros/src/lib.rs
+++ b/profiling-procmacros/src/lib.rs
@@ -30,6 +30,38 @@ pub fn skip(
     item
 }
 
+#[proc_macro_attribute]
+pub fn impl(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let mut content = parse_macro_input!(item as ItemImpl);
+    'func_loop: for block in &mut content.items {
+        match block {
+            ImplItem::Fn(ref mut func) => {
+                for func_attr in &func.attrs {
+                    match func_attr.meta {
+                        syn::Meta::Path(ref func_path) => {
+                            let path_seg = func_path.segments.last().unwrap();
+                            if path_seg.ident.to_string() == "skip".to_string() {
+                                continue 'func_loop;
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+                let prev_block = &func.block;
+                let func_name = func.sig.ident.to_string();
+                func.block = impl_block(prev_block, &func_name);
+            }
+            _ => {}
+        }
+    }
+    // println!("item: \"{:?}\"", content.attrs.);
+
+    (quote!(
+        #content
+    ))
+    .into()
+}
+
 #[cfg(not(any(
     feature = "profile-with-puffin",
     feature = "profile-with-optick",

--- a/profiling-procmacros/src/lib.rs
+++ b/profiling-procmacros/src/lib.rs
@@ -31,7 +31,7 @@ pub fn skip(
 }
 
 #[proc_macro_attribute]
-pub fn auto_impl(
+pub fn all_functions(
     _attr: TokenStream,
     item: TokenStream,
 ) -> TokenStream {

--- a/profiling-procmacros/src/lib.rs
+++ b/profiling-procmacros/src/lib.rs
@@ -1,6 +1,6 @@
 extern crate proc_macro;
 use proc_macro::TokenStream;
-use quote::quote;
+use quote::{quote, ToTokens};
 use syn::{parse_macro_input, parse_quote, ImplItem, ItemFn, ItemImpl};
 
 #[proc_macro_attribute]
@@ -36,6 +36,8 @@ pub fn auto_impl(
     item: TokenStream,
 ) -> TokenStream {
     let mut content = parse_macro_input!(item as ItemImpl);
+    let struct_name = content.self_ty.to_token_stream().to_string();
+
     'func_loop: for block in &mut content.items {
         // Currently, we only care about the function impl part.
         // In the future, expand the code to following if we are interested in other parts
@@ -71,8 +73,8 @@ pub fn auto_impl(
             }
         }
         let prev_block = &func.block;
-        let func_name = func.sig.ident.to_string();
-        func.block = impl_block(prev_block, &func_name);
+        let calling_info = format!("{}: {}", struct_name, func.sig.ident);
+        func.block = impl_block(prev_block, &calling_info);
     }
 
     (quote!(

--- a/profiling-procmacros/src/lib.rs
+++ b/profiling-procmacros/src/lib.rs
@@ -22,6 +22,14 @@ pub fn function(
     .into()
 }
 
+#[proc_macro_attribute]
+pub fn skip(
+    _attr: TokenStream,
+    item: TokenStream,
+) -> TokenStream {
+    item
+}
+
 #[cfg(not(any(
     feature = "profile-with-puffin",
     feature = "profile-with-optick",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 ///     // some data...
 /// }
 ///
-/// #[profiling::auto_impl]
+/// #[profiling::all_functions]
 /// impl Foo {
 ///     pub fn do_something(&self) {
 ///         // some code...    
@@ -45,7 +45,7 @@
 /// }
 /// ```
 #[cfg(feature = "procmacros")]
-pub use profiling_procmacros::auto_impl;
+pub use profiling_procmacros::all_functions;
 /// Proc macro for creating a scope around the function, using the name of the function for the
 /// scope's name
 ///
@@ -65,7 +65,7 @@ pub use profiling_procmacros::function;
 ///     // some data...
 /// }
 ///
-/// #[profiling::auto_impl]
+/// #[profiling::all_functions]
 /// impl Foo {
 ///     pub fn do_something(&self) {
 ///         // some code...    

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,43 @@
 // likely will bring in std.
 #![no_std]
 
+/// Proc macro for creating a scope around each function under struct impl block
+/// ```
+/// pub struct Foo {
+///     // some data...
+/// }
+///
+/// #[profiling::auto_impl]
+/// impl Foo {
+///     pub fn new() -> Self {
+///         // some code...    
+///     }
+///
+///     pub fn do_something(&self) {
+///         // some code...
+///     }
+/// }
+/// ```
+///
+/// The following will generate the same code
+///
+/// ```
+/// pub struct Foo {
+///     // some data...
+/// }
+///
+/// impl Foo {
+///     #[profiling::function]
+///     pub fn new() -> Self {
+///         // some code...    
+///     }
+///
+///     #[profiling::function]
+///     pub fn do_something(&self) {
+///         // some code...
+///     }
+/// }
+/// ```
 #[cfg(feature = "procmacros")]
 pub use profiling_procmacros::auto_impl;
 /// Proc macro for creating a scope around the function, using the name of the function for the
@@ -22,6 +59,43 @@ pub use profiling_procmacros::auto_impl;
 /// ```
 #[cfg(feature = "procmacros")]
 pub use profiling_procmacros::function;
+/// Proc macro to skip the auto_impl for the function
+/// ```
+/// pub struct Foo {
+///     // some data...
+/// }
+///
+/// #[profiling::auto_impl]
+/// impl Foo {
+///     pub fn new() -> Self {
+///         // some code...    
+///     }
+///
+///     #[profiling::skip]
+///     pub fn do_something(&self) {
+///         // some code...
+///     }
+/// }
+/// ```
+///
+/// The following will generate the same code
+///
+/// ```
+/// pub struct Foo {
+///     // some data...
+/// }
+///
+/// impl Foo {
+///     #[profiling::function]
+///     pub fn new() -> Self {
+///         // some code...    
+///     }
+///
+///     pub fn do_something(&self) {
+///         // some code...
+///     }
+/// }
+/// ```
 #[cfg(feature = "procmacros")]
 pub use profiling_procmacros::skip;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,11 +15,11 @@
 ///
 /// #[profiling::auto_impl]
 /// impl Foo {
-///     pub fn new() -> Self {
+///     pub fn do_something(&self) {
 ///         // some code...    
 ///     }
 ///
-///     pub fn do_something(&self) {
+///     pub fn do_otherthing(&self) {
 ///         // some code...
 ///     }
 /// }
@@ -34,12 +34,12 @@
 ///
 /// impl Foo {
 ///     #[profiling::function]
-///     pub fn new() -> Self {
+///     pub fn do_something(&self) {
 ///         // some code...    
 ///     }
 ///
 ///     #[profiling::function]
-///     pub fn do_something(&self) {
+///     pub fn do_otherthing(&self) {
 ///         // some code...
 ///     }
 /// }
@@ -67,12 +67,12 @@ pub use profiling_procmacros::function;
 ///
 /// #[profiling::auto_impl]
 /// impl Foo {
-///     pub fn new() -> Self {
+///     pub fn do_something(&self) {
 ///         // some code...    
 ///     }
 ///
 ///     #[profiling::skip]
-///     pub fn do_something(&self) {
+///     pub fn do_otherthing(&self) {
 ///         // some code...
 ///     }
 /// }
@@ -87,11 +87,11 @@ pub use profiling_procmacros::function;
 ///
 /// impl Foo {
 ///     #[profiling::function]
-///     pub fn new() -> Self {
+///     pub fn do_something(&self) {
 ///         // some code...    
 ///     }
 ///
-///     pub fn do_something(&self) {
+///     pub fn do_otherthing(&self) {
 ///         // some code...
 ///     }
 /// }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,8 @@
 // likely will bring in std.
 #![no_std]
 
+#[cfg(feature = "procmacros")]
+pub use profiling_procmacros::auto_impl;
 /// Proc macro for creating a scope around the function, using the name of the function for the
 /// scope's name
 ///
@@ -20,6 +22,8 @@
 /// ```
 #[cfg(feature = "procmacros")]
 pub use profiling_procmacros::function;
+#[cfg(feature = "procmacros")]
+pub use profiling_procmacros::skip;
 
 #[cfg(feature = "profile-with-puffin")]
 pub use puffin;


### PR DESCRIPTION
# Description

`#[profiling::auto_impl]` and `#[profiling::skip]` have been added along with their corresponding examples and docs.

Usage：
```rust
struct Foo {
    // some data
}

#[profiling::auto_impl]
impl Foo {
    pub fn with_auto_impl() {
        // some code...
    }

    #[profiling::skip]
    pub fn without_auto_impl() {
        // some code...
    }
}
```

This should generate the same code:
```rust
impl Foo {
    #[profiling::function]
    pub fn with_auto_impl() {
        // some code...
    }

    pub fn without_auto_impl() {
        // some code...
    }
}
```

# Connections
Close #37 

# Tests
`cargo run --example simple --features="profile-with-tracy"` then use `Tracy` to generate this pic:
<img width="594" alt="屏幕截图 2023-08-16 152128" src="https://github.com/aclysma/profiling/assets/14981363/42af0f9d-afcc-4a3f-8c1b-e1c5c3d7decb">

`cargo expand --example simple --features="profile-with-tracy"` to get the following code:
```rust
struct Foo;
impl Foo {
    pub fn with_auto_impl() {
        let _tracy_span = {
            let location = {
                struct S;
                static LOC: ::tracy_client::internal::Lazy<
                    ::tracy_client::internal::SpanLocation,
                > = ::tracy_client::internal::Lazy::new(|| {
                    ::tracy_client::internal::make_span_location(
                        ::tracy_client::internal::type_name::<S>(),
                        "with_auto_impl\u{0}".as_ptr(),
                        "examples/simple.rs\u{0}".as_ptr(),
                        16u32,
                    )
                });
                &*LOC
            };
            ::tracy_client::Client::running()
                .expect("span! without a running Client")
                .span(location, 0)
        };
        {
            some_other_function(5);
        }
    }
    pub fn without_auto_impl() {
        some_other_function(5);
    }
}
```

# Summary
These two macros should work as expected. It's important to note that #[profiling::skip] is meant to be used in conjunction with #[profiling::auto_impl]. When used alone, it won't have any effect on the code.

Any feedbacks or suggestions for improvement are welcome.