### PR TITLE
Only depend on `profiling-procmacros` if the `procmacros` feature was set

### DIFF
--- a/profiling/Cargo.toml
+++ b/profiling/Cargo.toml
@@ -7,6 +7,7 @@ description = "This crate provides a very thin abstraction over other profiler c
 license = "MIT OR Apache-2.0"
 readme = "../README.md"
 repository = "https://github.com/aclysma/profiling"
+rust-version = "1.60"
 homepage = "https://github.com/aclysma/profiling"
 keywords = ["performance", "profiling"]
 categories = ["development-tools::profiling"]
@@ -33,11 +34,17 @@ tracing-subscriber = { version = "0.2" }
 
 [features]
 default = ["procmacros"]
-profile-with-puffin = ["puffin", "profiling-procmacros/profile-with-puffin"]
-profile-with-optick = ["optick", "profiling-procmacros/profile-with-optick"]
-profile-with-superluminal = ["superluminal-perf", "profiling-procmacros/profile-with-superluminal"]
-profile-with-tracing = ["tracing", "profiling-procmacros/profile-with-tracing"]
-profile-with-tracy = ["tracy-client", "profiling-procmacros/profile-with-tracy"]
+profile-with-puffin = ["puffin", "profiling-procmacros?/profile-with-puffin"]
+profile-with-optick = ["optick", "profiling-procmacros?/profile-with-optick"]
+profile-with-superluminal = [
+    "superluminal-perf",
+    "profiling-procmacros?/profile-with-superluminal",
+]
+profile-with-tracing = ["tracing", "profiling-procmacros?/profile-with-tracing"]
+profile-with-tracy = [
+    "tracy-client",
+    "profiling-procmacros?/profile-with-tracy",
+]
 type-check = []
 procmacros = ["profiling-procmacros"]
 


### PR DESCRIPTION
Previously `profiling = { version = "1.0.12", optional = true, default-features = false, features = ["profile-with-puffin"] }` would still add `profiling-procmacros` as a dependency.

To support this, MSRV must be increased to 1.60 (released 2022-04-07)