### PR TITLE
Update puffin to v0.19

### DIFF
--- a/demo-puffin/Cargo.toml
+++ b/demo-puffin/Cargo.toml
@@ -20,11 +20,11 @@ categories = ["development-tools::profiling"]
 [dependencies]
 profiling = { path = "../profiling", features = ["profile-with-puffin"] }
 
-puffin = "0.18.0"
-puffin_egui = "0.24.0"
-egui = "0.24.0"
+puffin = "0.19.0"
+puffin_egui = "0.25.0"
+egui = "0.25.0"
 # wgpu also works fine here
-eframe = { version = "0.24.0", default-features = false, features = ["glow"] }
+eframe = { version = "0.25.0", default-features = false, features = ["glow"] }
 
 log = "0.4"
 env_logger = "0.6"

--- a/profiling/Cargo.toml
+++ b/profiling/Cargo.toml
@@ -16,7 +16,7 @@ exclude = ["/examples", "/screenshots"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-puffin = { version = "0.18", optional = true }
+puffin = { version = "0.19", optional = true }
 optick = { version = "1.3", optional = true }
 tracing = { version = "0.1", optional = true }
 tracy-client = { version = "0.16.2", optional = true }


### PR DESCRIPTION
Also brings example code up to date with related dependencies (egui, eframe, puffin-egui).