### PR TITLE
Specify `profiling-procmacros` MSRV in Cargo.toml

### DIFF
--- a/profiling-procmacros/Cargo.toml
+++ b/profiling-procmacros/Cargo.toml
@@ -10,8 +10,7 @@ repository = "https://github.com/aclysma/profiling"
 homepage = "https://github.com/aclysma/profiling"
 keywords = ["performance", "profiling"]
 categories = ["development-tools::profiling"]
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+rust-version = "1.65"
 
 [dependencies]
 quote = { version = "1.0", default-features = false }


### PR DESCRIPTION
This is basically metadata. lib.rs in profiling-procmacros uses `let-else` which was [stabilized in 1.65.0](https://blog.rust-lang.org/2022/11/03/Rust-1.65.0.html).

Specifying this can help downstream crates with their MSRVs and also gives better error messages:

Before:

```rs
> cargo +1.61 c -p profiling-procmacros
error[E0658]: `let...else` statements are unstable
  --> profiling-procmacros/src/lib.rs:63:9
   |
63 | /         let ImplItem::Fn(ref mut func) = block else {
64 | |             continue;
65 | |         };
   | |__________^
   |
   = note: see issue #87335 <https://github.com/rust-lang/rust/issues/87335> for more information
```

After:

```
> cargo +1.61 c -p profiling-procmacros
error: package `profiling-procmacros v1.0.15 cannot be built because it requires rustc 1.65 or newer, while the currently active rustc version is 1.61.0
```