### PR TITLE
Fix cargo-deny CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
 
       - uses: EmbarkStudios/cargo-deny-action@v1
         with:
-          arguments: --manifest-path=demo-puffin/Cargo.toml
+          manifest-path: demo-puffin/Cargo.toml
           command: check ${{ matrix.checks }}
 
   clean:


### PR DESCRIPTION
A new input "manifest-path" was added in [1.5.14](https://github.com/EmbarkStudios/cargo-deny-action/commit/549bc5214b02810b85f8f56188b9ee753f83f199), but not documented. It also breaks `argument: --manifest-path <...>` usage, so using it is necessary now.