### PR TITLE
Update CI dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on: [push, pull_request]
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  RUSTFLAGS: "-C debuginfo=0 -D warnings"
 
 # Just test windows as several of the profilers don't do anything or fail to build on other platforms
 jobs:
@@ -25,70 +27,40 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs: clean
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}
-          override: true
-
-      - uses: actions/cache@v2
-        with:
-          path: |
-            target
-          key: ${{ runner.os }}-cargo-check-test-${{ matrix.toolchain }}-${{ hashFiles('**/Cargo.lock') }}
+      - uses: Swatinem/rust-cache@v2
 
       - name: Build (puffin)
         run: cargo build --package=profiling --features=profile-with-puffin
-        env:
-          CARGO_INCREMENTAL: 0
-          RUSTFLAGS: "-C debuginfo=0 -D warnings"
 
       - name: Build (superluminal)
-        run: cargo build --package=profiling --features=profile-with-superluminal
         if: ${{ runner.os == 'Windows' && matrix.toolchain == 'stable' }}
-        env:
-          CARGO_INCREMENTAL: 0
-          RUSTFLAGS: "-C debuginfo=0 -D warnings"
+        run: cargo build --package=profiling --features=profile-with-superluminal
 
       - name: Build (optick)
-        run: cargo build --package=profiling --features=profile-with-optick
         if: ${{ runner.os == 'Windows' && matrix.toolchain == 'stable' }}
-        env:
-          CARGO_INCREMENTAL: 0
-          RUSTFLAGS: "-C debuginfo=0 -D warnings"
+        run: cargo build --package=profiling --features=profile-with-optick
 
       - name: Build (tracing)
         run: cargo build --package=profiling --features=profile-with-tracing
-        env:
-          CARGO_INCREMENTAL: 0
-          RUSTFLAGS: "-C debuginfo=0 -D warnings"
 
       - name: Build (tracy)
         run: cargo build --package=profiling --features=profile-with-tracy
-        env:
-          CARGO_INCREMENTAL: 0
-          RUSTFLAGS: "-C debuginfo=0 -D warnings"
 
       - name: Build (type-check)
         run: cargo build --package=profiling --features=type-check
-        env:
-          CARGO_INCREMENTAL: 0
-          RUSTFLAGS: "-C debuginfo=0 -D warnings"
 
       # Only do this on windows, some of the profilers only support windows
       - name: Run tests
-        run: cargo test --workspace
         if: ${{ runner.os == 'Windows' && matrix.toolchain == 'stable' }}
-        env:
-          CARGO_INCREMENTAL: 0
-          RUSTFLAGS: "-C debuginfo=0 -D warnings"
+        run: cargo test --workspace
 
       # Test that we compile with no default features enabled
-      - name: Run tests (
+      - name: Build without default features
         run: cargo build --no-default-features
-        env:
-          CARGO_INCREMENTAL: 0
-          RUSTFLAGS: "-C debuginfo=0 -D warnings"
 
   build-demo:
     strategy:
@@ -104,25 +76,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs: build
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}
-          override: true
-
-      - uses: actions/cache@v2
-        with:
-          path: |
-            target
-          key: ${{ runner.os }}-cargo-check-test-${{ matrix.toolchain }}-${{ hashFiles('**/Cargo.lock') }}
+      - uses: Swatinem/rust-cache@v2
 
       - name: Build (demo-puffin)
         working-directory: ./demo-puffin
         run: cargo build --package=demo-puffin
-
-        env:
-          CARGO_INCREMENTAL: 0
-          RUSTFLAGS: "-C debuginfo=0 -D warnings"
 
   deny-check:
     name: cargo-deny
@@ -141,12 +103,10 @@ jobs:
   clean:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
           components: rustfmt, clippy
-          override: true
 
       - name: Check the format
         run: cargo fmt --all -- --check
@@ -156,53 +116,39 @@ jobs:
           cargo clippy
           --package=profiling
           --features profile-with-puffin
-          --
-          -D warnings
 
       - name: Run clippy (optick)
         run: >
           cargo clippy
           --package=profiling
           --features profile-with-optick
-          --
-          -D warnings
 
       - name: Run clippy (superluminal)
         run: >
           cargo clippy
           --package=profiling
           --features profile-with-superluminal
-          --
-          -D warnings
 
       - name: Run clippy (tracing)
         run: >
           cargo clippy
           --package=profiling
           --features profile-with-tracing
-          --
-          -D warnings
 
       - name: Run clippy (tracy)
         run: >
           cargo clippy
           --package=profiling
           --features profile-with-tracy
-          --
-          -D warnings
 
       - name: Run clippy (type-check)
         run: >
           cargo clippy
           --package=profiling
           --features type-check
-          --
-          -D warnings
 
       - name: Run clippy (demo-puffin)
         working-directory: ./demo-puffin
         run: >
           cargo clippy
           --package=demo-puffin
-          --
-          -D warnings


### PR DESCRIPTION
Functionality should be the same as before.

Update or replace the following dependencies:

- Update actions/checkout from v2 to v4: fixes warnings about Node JS version
- Replace actions-rs/toolchain with dtolnay/rust-toolchain: actions-rs/toolchain has been unmaintained for some time and is now archived. Note: `override` is no now unnecessary, the specified toolchain will be set as `rustup default`
- Replace actions/cache with Swatinem/rust-cache: Easier, does what you'd expect out of the box. Note: This is technically a change in behavior. `build` and `build-demo` get separate caches now, but this shouldn't be a problem right?

Also refactor a bit:

- Set `CARGO_*`/`RUSTFLAGS` environment variables for entire workflow
- Reorder some properties for readability (name -> if -> run)
- Fix a typo/wrong name for a job step (Build without default features)