### PR TITLE
Specify MSRV for `profiling` and `profiling-procmacros` and verify in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,20 +12,16 @@ jobs:
   build:
     strategy:
       matrix:
-        toolchain: [stable, beta, 1.70.0]
+        toolchain: [stable, beta]
         os: [windows-2022, ubuntu-22.04, macos-12]
         exclude:
           - os: macos-12
             toolchain: beta
           - os: windows-2022
             toolchain: beta
-          - os: macos-12
-            toolchain: 1.70.0
-          - os: windows-2022
-            toolchain: 1.70.0
 
     runs-on: ${{ matrix.os }}
-    needs: clean
+    needs: [clean, check-msrv]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
@@ -99,6 +95,32 @@ jobs:
         with:
           manifest-path: demo-puffin/Cargo.toml
           command: check ${{ matrix.checks }}
+
+  check-msrv:
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        config:
+          - package: profiling
+            msrv: '1.60'
+            extra-args: --no-default-features
+          - package: profiling-procmacros
+            msrv: '1.65'
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.config.msrv }}
+
+      - uses: Swatinem/rust-cache@v2
+
+      # Running cargo check should be enough to find MSRV problems
+      - name: Verify MSRV
+        run: >
+          cargo check
+          -p ${{ matrix.config.package }}
+          ${{ matrix.config.extra-args }}
 
   clean:
     runs-on: ubuntu-22.04

--- a/profiling-procmacros/Cargo.toml
+++ b/profiling-procmacros/Cargo.toml
@@ -10,8 +10,7 @@ repository = "https://github.com/aclysma/profiling"
 homepage = "https://github.com/aclysma/profiling"
 keywords = ["performance", "profiling"]
 categories = ["development-tools::profiling"]
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+rust-version = "1.65"
 
 [dependencies]
 quote = { version = "1.0", default-features = false }

--- a/profiling/Cargo.toml
+++ b/profiling/Cargo.toml
@@ -11,8 +11,7 @@ homepage = "https://github.com/aclysma/profiling"
 keywords = ["performance", "profiling"]
 categories = ["development-tools::profiling"]
 exclude = ["/examples", "/screenshots"]
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+rust-version = "1.60"
 
 [dependencies]
 puffin = { version = "0.19", optional = true }


### PR DESCRIPTION
Supersedes #69. (See that PR for discussion)

The cache entries for `check-msrv` are relatively big (~450MiB). This seems to be [intended.](https://github.com/Swatinem/rust-cache/issues/11) Any rust version >= 1.70 will use a different registry checkout mode (sparse), so newer versions don't have this issue.

If cache size is a concern, I could look into fixing this manually.