### PR TITLE
WIP: Don't add additional scope when profile is not enabled

### DIFF
--- a/profiling-procmacros/src/lib.rs
+++ b/profiling-procmacros/src/lib.rs
@@ -99,9 +99,7 @@ fn impl_block(
     _instrumented_function_name: &str,
 ) -> syn::Block {
     parse_quote! {
-        {
-            #body
-        }
+        #body
     }
 }
 


### PR DESCRIPTION
The additional scope break some clippy lint detection (like `missing_errors_doc`)
This Fix #75 

WIP: the change affect only when no profiling instrumentation is enabled.
But if the puffin (by example) instrumentation is enabled, the problem is here again.
And when I have tried remove the additional brace too in `impl_block` of `profile-with-puffin`, the macro failed with :
```
error: custom attribute panicked
 --> profiling/examples/simple.rs:8:1
  |
8 | #[profiling::all_functions]
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = help: message: expected curly braces
```