### PR TITLE
Use the built in function name for tracy instead of passing it along manually when using #[profiling::function]

### DIFF
--- a/profiling-procmacros/src/lib.rs
+++ b/profiling-procmacros/src/lib.rs
@@ -165,12 +165,12 @@ fn impl_block(
 #[cfg(feature = "profile-with-tracy")]
 fn impl_block(
     body: &syn::Block,
-    instrumented_function_name: &str,
+    _instrumented_function_name: &str,
 ) -> syn::Block {
     parse_quote! {
         {
             // Note: callstack_depth is 0 since this has significant overhead
-            let _tracy_span = profiling::tracy_client::span!(#instrumented_function_name, 0);
+            let _tracy_span = profiling::tracy_client::span!();
 
             #body
         }


### PR DESCRIPTION
We're currently passing along the name of the function manually in the implementation for `#[profiling::function]` for tracy. However the `tracy_client` has it's own code to figure out the calling function name built in, passing along the function name as the span name makes it appear twice in the profiling output. This change should improve consistency with logging done by the native crate and by the profiling crate.

Before changes: Notice duplicate function name reported:
![image](https://github.com/user-attachments/assets/ef9436d4-3731-46ff-b10f-01ebef79eb1d)

After changes:
![image](https://github.com/user-attachments/assets/bbc68e54-e000-44bf-8031-e6c65f70dcbe)
