### PR TITLE
Add tracing-tracy frame marker in profiling::finish_frame!() for the tracing backend

### DIFF
--- a/profiling/src/tracing_impl.rs
+++ b/profiling/src/tracing_impl.rs
@@ -18,5 +18,7 @@ macro_rules! register_thread {
 
 #[macro_export]
 macro_rules! finish_frame {
-    () => {};
+    () => {
+        $crate::tracing::event!($crate::tracing::Level::INFO, tracy.frame_mark = true);
+    };
 }


### PR DESCRIPTION
This adds support for profiling::finish_frame!() when using the `tracing` backend from `tracing-tracy`.

`tracing-tracy` inspects logged tracing events for the `tracy.frame_mark = true` tag to trigger a new frame in tracy.

![image](https://github.com/user-attachments/assets/a70ae1eb-ab07-4cb3-aed1-ed55ee2efea9)
