### PR TITLE
Some cleanup changes

### DIFF
--- a/demo-puffin/src/main.rs
+++ b/demo-puffin/src/main.rs
@@ -30,7 +30,7 @@ fn some_inner_function(_iteration_index: usize) {
     burn_time(1);
 }
 
-fn some_macro_function(){
+fn some_macro_function() {
     profiling::function_scope!();
     burn_time(5);
 }
@@ -119,6 +119,6 @@ fn main() -> eframe::Result<()> {
     eframe::run_native(
         "eframe template",
         native_options,
-        Box::new(|cc| Ok(Box::new(TemplateApp::new(cc))))
+        Box::new(|cc| Ok(Box::new(TemplateApp::new(cc)))),
     )
 }

--- a/profiling/examples/simple.rs
+++ b/profiling/examples/simple.rs
@@ -50,7 +50,8 @@ fn some_other_function(iterations: usize) {
     burn_time(5);
 
     {
-        profiling::scope!("do iterations");
+        // Make this a non-literal to touch more of the API
+        profiling::scope!(&"do iterations".to_string());
         for i in 0..iterations {
             profiling::scope!(
                 "some_inner_function_that_sleeps",

--- a/profiling/src/superluminal_impl.rs
+++ b/profiling/src/superluminal_impl.rs
@@ -12,20 +12,20 @@ macro_rules! scope {
 #[macro_export]
 macro_rules! function_scope {
     () => {
-        let function_name = {
+        let _function_name = {
             struct S;
             let type_name = core::any::type_name::<S>();
             &type_name[..type_name.len() - 3]
         };
-        $crate::scope!(function_name);
+        $crate::scope!(_function_name);
     };
     ($data:expr) => {
-        let function_name = {
+        let _function_name = {
             struct S;
             let type_name = core::any::type_name::<S>();
             &type_name[..type_name.len() - 3]
         };
-        $crate::scope!(function_name, $data);
+        $crate::scope!(_function_name, $data);
     };
 }
 

--- a/profiling/src/tracing_impl.rs
+++ b/profiling/src/tracing_impl.rs
@@ -10,7 +10,6 @@ macro_rules! scope {
     };
 }
 
-// NOTE: Not supported as tracing does not support non literal spans. Use #[profiling::function] instead.
 #[macro_export]
 macro_rules! function_scope {
     () => {
@@ -19,13 +18,13 @@ macro_rules! function_scope {
             let type_name = core::any::type_name::<S>();
             &type_name[..type_name.len() - 3]
         };
-        let span = $crate::tracing::span!(
+        let _span = $crate::tracing::span!(
             $crate::tracing::Level::INFO,
             "function_scope",
             "{}",
             function_name
         );
-        let _span_entered = span.enter();
+        let _span_entered = _span.enter();
     };
     ($data:expr) => {
         let function_name = {
@@ -33,13 +32,14 @@ macro_rules! function_scope {
             let type_name = core::any::type_name::<S>();
             &type_name[..type_name.len() - 3]
         };
-        let span = $crate::tracing::span!(
+        let _span = $crate::tracing::span!(
             $crate::tracing::Level::INFO,
             "function_scope",
             tag = $data,
             "{}",
             function_name
         );
+        let _span_entered = _span.enter();
     };
 }
 

--- a/profiling/src/tracy_impl.rs
+++ b/profiling/src/tracy_impl.rs
@@ -11,7 +11,7 @@ macro_rules! scope {
         _tracy_span.emit_text($data);
     };
     ($name:expr) => {
-        let function_name = {
+        let _function_name = {
             struct S;
             let type_name = core::any::type_name::<S>();
             &type_name[..type_name.len() - 3]
@@ -19,10 +19,10 @@ macro_rules! scope {
         let _tracy_span = $crate::tracy_client::Client::running()
             .expect("scope! without a running tracy_client::Client")
             // Note: callstack_depth is 0 since this has significant overhead
-            .span_alloc(Some($name), function_name, file!(), line!(), 0);
+            .span_alloc(Some($name), _function_name, file!(), line!(), 0);
     };
     ($name:expr, $data:expr) => {
-        let function_name = {
+        let _function_name = {
             struct S;
             let type_name = core::any::type_name::<S>();
             &type_name[..type_name.len() - 3]
@@ -30,7 +30,7 @@ macro_rules! scope {
         let _tracy_span = $crate::tracy_client::Client::running()
             .expect("scope! without a running tracy_client::Client")
             // Note: callstack_depth is 0 since this has significant overhead
-            .span_alloc(Some($name), function_name, file!(), line!(), 0);
+            .span_alloc(Some($name), _function_name, file!(), line!(), 0);
         _tracy_span.emit_text($data);
     };
 }
@@ -38,14 +38,14 @@ macro_rules! scope {
 #[macro_export]
 macro_rules! function_scope {
     () => {
-        $crate::tracy_client::span!();
+        let _tracy_span = $crate::tracy_client::span!();
     };
     ($data:expr) => {
-        let location = $crate::tracy_client::span_location!();
-        let tracy_span = $crate::tracy_client::Client::running()
+        let _location = $crate::tracy_client::span_location!();
+        let _tracy_span = $crate::tracy_client::Client::running()
             .expect("function_scope! without a running tracy_client::Client")
-            .span(location, 0);
-        tracy_span.emit_text($data);
+            .span(_location, 0);
+        _tracy_span.emit_text($data);
     };
 }
 


### PR DESCRIPTION
 - Fix case where span.enter() is not called on tracing backend
 - Address warnings of unused return values with the tracy backend
 - Rename local variables to begin with _ to avoid polluting namespace
 - Remove a stale comment
 - Run cargo fmt