### PR TITLE
fix: discard arguments in empty backend

### DIFF
--- a/profiling/src/empty_impl.rs
+++ b/profiling/src/empty_impl.rs
@@ -12,8 +12,13 @@
 /// ```
 #[macro_export]
 macro_rules! scope {
-    ($name:expr) => {};
-    ($name:expr, $data:expr) => {};
+    ($name:expr) => {
+        let _ = $name;
+    };
+    ($name:expr, $data:expr) => {
+        let _ = $name;
+        let _ = $data;
+    };
 }
 
 /// Opens a scope automatically named after the current function.
@@ -31,7 +36,9 @@ macro_rules! scope {
 #[macro_export]
 macro_rules! function_scope {
     () => {};
-    ($data:expr) => {};
+    ($data:expr) => {
+        let _ = $data;
+    };
 }
 
 /// Registers a thread with the profiler API(s). This is usually setting a name for the thread.
@@ -41,7 +48,9 @@ macro_rules! function_scope {
 #[macro_export]
 macro_rules! register_thread {
     () => {};
-    ($name:expr) => {};
+    ($name:expr) => {
+        let _ = $name;
+    };
 }
 
 /// Finishes the frame. This isn't strictly necessary for some kinds of applications but a pretty


### PR DESCRIPTION
The WGPU project uses `profiling` for debugging, and speaking as a maintainer of it, it's been lovely. Thank you so much for this crate!

We wanted to give back by fixing an issue we noticed just now in <https://github.com/gfx-rs/wgpu/pull/6422#issuecomment-2420886968> where arguments to `profiling` macros aren't evaluated. This causes the compiler to completely ignore whatever is provided as arguments when no features/backends for `profiling` are enabled. In turn, this can cause divergence in compiler errors if one accidentally writes code that wouldn't compile when a backend is disabled. For example, this Rust program compiles just fine with `profiling` 1.0.16 and `default-features = false`:


```rust
fn main() {
	profiling::scope!(blarg, unsafe { absolute_nonsense });
}
```

As soon as a feature corresponding to a backend of `profiling` is enabled, the above would fail to compile, as one might expect. This is because Rust actually tries to use the expression arguments provided.

This PR fixes this by explicitly discarding each argument in the empty backend, thus forcing Rust to actually try to use the expressions written. This should make any code written against the empty backend portable across all backends.