### PR TITLE
Update superluminal-perf

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -77,7 +77,8 @@ allow = [
     "Unicode-DFS-2016",
     "BSD-2-Clause",
     "BSL-1.0",
-    "ISC"
+    "ISC",
+    "Unicode-3.0"
     #"Apache-2.0 WITH LLVM-exception",
 ]
 # List of explictly disallowed licenses

--- a/profiling/Cargo.toml
+++ b/profiling/Cargo.toml
@@ -18,7 +18,7 @@ puffin = { version = "0.19", optional = true }
 optick = { version = "1.3", optional = true }
 tracing = { version = "0.1", optional = true }
 tracy-client = { version = "0.17", optional = true }
-superluminal-perf = { version = "0.1", optional = true }
+superluminal-perf = { version = "0.4", optional = true }
 profiling-procmacros = { version = "1.0.16", path = "../profiling-procmacros", optional = true }
 
 [dev-dependencies]

--- a/profiling/examples/simple.rs
+++ b/profiling/examples/simple.rs
@@ -157,8 +157,12 @@ fn main() {
 
     // Test that non-literals can be used
     //
-    // Does not work with these two backends:
-    #[cfg(not(any(feature = "profile-with-puffin", feature = "profile-with-tracing")))]
+    // Does not work with these three backends:
+    #[cfg(not(any(
+        feature = "profile-with-puffin",
+        feature = "profile-with-tracing",
+        feature = "profile-with-superluminal"
+    )))]
     // optick backend currently won't work with multiple `profiling::scope!` in the same scope
     #[cfg(not(any(feature = "profile-with-optick")))]
     {

--- a/profiling/src/superluminal_impl.rs
+++ b/profiling/src/superluminal_impl.rs
@@ -63,13 +63,13 @@ pub mod superluminal {
     const DEFAULT_SUPERLUMINAL_COLOR: u32 = 0xFFFFFFFF;
 
     impl SuperluminalGuard {
-        pub fn new(name: &str) -> Self {
+        pub fn new(name: &'static str) -> Self {
             superluminal_perf::begin_event(name);
             SuperluminalGuard
         }
 
         pub fn new_with_data(
-            name: &str,
+            name: &'static str,
             data: &str,
         ) -> Self {
             superluminal_perf::begin_event_with_data(name, data, DEFAULT_SUPERLUMINAL_COLOR);


### PR DESCRIPTION
The new Superluminal requires a new tracepoint message format since their V2 release.
This is included now in 0.4 release of the library.

I also had to fix some `static` requirements on lifetimes for names of tracepoints.  