### PR TITLE
Update tracy-client

### DIFF
--- a/profiling/Cargo.toml
+++ b/profiling/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.60"
 puffin = { version = "0.19", optional = true }
 optick = { version = "1.3", optional = true }
 tracing = { version = "0.1", optional = true }
-tracy-client = { version = "0.17", optional = true }
+tracy-client = { version = "0.18", optional = true }
 superluminal-perf = { version = "0.4", optional = true }
 profiling-procmacros = { version = "1.0.16", path = "../profiling-procmacros", optional = true }
 


### PR DESCRIPTION
tracy-client 0.18.1 bumped tracy-client-sys from 0.24.3 to 0.25.0, so an update in `profiling` is required to be able to use it together with the new tracy-client (you can't have two -sys copies in the dependency tree).